### PR TITLE
  Detailed error responses when missing fields.

### DIFF
--- a/src/main/java/echoquery/intents/AggregationHandler.java
+++ b/src/main/java/echoquery/intents/AggregationHandler.java
@@ -34,12 +34,6 @@ public class AggregationHandler implements IntentHandler {
    * Exposed for testing purposes - SpeechletResponse is impossible to inspect.
    */
   public String getResponseInEnglish(Intent intent, Session session) {
-    try {
-      QueryResult result = querier.execute(QueryRequest.of(intent));
-      return result.toEnglish();
-    } catch (SQLException e) {
-      log.info("StatementCreationError: " + e.getMessage());
-      return "There was an error querying the database.";
-    }
+    return querier.execute(QueryRequest.of(intent)).getMessage();
   }
 }

--- a/src/main/java/echoquery/sql/Querier.java
+++ b/src/main/java/echoquery/sql/Querier.java
@@ -13,6 +13,11 @@ import echoquery.sql.QueryResult.Status;
 import echoquery.sql.formatter.SqlFormatter;
 import echoquery.utils.SlotUtil;
 
+/**
+ * The Querier class takes in an unbuilt QueryRequest object, validates that its
+ * contents are well-formed, builds, then executes the query.
+ */
+
 public class Querier {
 
   private static final Logger log = LoggerFactory.getLogger(Querier.class);
@@ -24,6 +29,11 @@ public class Querier {
     this.inferrer = new SchemaInferrer(conn);
   }
 
+  /**
+   * Validate then execute a QueryRequest.
+   * @param request
+   * @return A QueryResult with either a success or failure status and message.
+   */
   public QueryResult execute(QueryRequest request) {
     // First validate the request, interactively mending malformed requests.
     Optional<QueryResult> invalidation = validate(request);
@@ -47,13 +57,21 @@ public class Querier {
     }
   }
 
+  /**
+   * Validate that the unbuilt fields in the QueryRequest are well formed to
+   * make sure no null pointer exceptions occur during the building process.
+   * @param request
+   * @return
+   */
   public Optional<QueryResult> validate(QueryRequest request) {
+    // FROM VALIDATION
     if (!request.getFromTable().isPresent()) {
       return Optional.of(new QueryResult(Status.FAILURE,
           "I'm not sure what table you're interested in, or maybe you referred "
           + "to one that doesn't exist? Please try again."));
     }
 
+    // AGGREGATION VALIDATION
     if (!request.getAggregationFunc().isPresent()) {
       return Optional.of(new QueryResult(Status.FAILURE,
           "I can't tell if you want to know the number of rows or the average, "
@@ -71,6 +89,7 @@ public class Querier {
           + " table. Please try again."));
     }
 
+    // WHERE VALIDATION: Loop through each clause.
     for (int i = 0; i < request.getComparisonColumns().size(); i++) {
       String index = "";
       switch (i) {
@@ -84,7 +103,6 @@ public class Querier {
           index = "third";
           break;
       }
-
       if (!request.getComparisonColumns().get(i).isPresent()) {
         return Optional.of(new QueryResult(Status.FAILURE,
             "I can't tell what column you're interested in filtering on in "
@@ -115,7 +133,6 @@ public class Querier {
             + " Please try again."));
       }
     }
-
     return Optional.empty();
   }
 }

--- a/src/main/java/echoquery/sql/Querier.java
+++ b/src/main/java/echoquery/sql/Querier.java
@@ -4,11 +4,14 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import echoquery.sql.QueryResult.Status;
 import echoquery.sql.formatter.SqlFormatter;
+import echoquery.utils.SlotUtil;
 
 public class Querier {
 
@@ -21,11 +24,98 @@ public class Querier {
     this.inferrer = new SchemaInferrer(conn);
   }
 
-  public QueryResult execute(QueryRequest request) throws SQLException {
+  public QueryResult execute(QueryRequest request) {
+    // First validate the request, interactively mending malformed requests.
+    Optional<QueryResult> invalidation = validate(request);
+    if (invalidation.isPresent()) {
+      return invalidation.get();
+    }
+    // If it gets here the request had all necessary fields, so now try to
+    // execute the SQL translation.
     String sql =
         SqlFormatter.formatSql(request.buildQuery(inferrer).getQuery());
-    Statement statement = conn.createStatement();
-    ResultSet result = statement.executeQuery(sql);
-    return new QueryResult(request, result);
+    try {
+      Statement statement = conn.createStatement();
+      ResultSet result = statement.executeQuery(sql);
+      return QueryResult.of(request, result);
+    } catch (SQLException e) {
+      log.error(e.getMessage());
+      return new QueryResult(Status.FAILURE,
+          "There was a problem with the execution of your query itself, "
+          + "perhaps a table or column was referenced that does not exist. "
+          + "Please try again. ");
+    }
+  }
+
+  public Optional<QueryResult> validate(QueryRequest request) {
+    if (!request.getFromTable().isPresent()) {
+      return Optional.of(new QueryResult(Status.FAILURE,
+          "I'm not sure what table you're interested in, or maybe you referred "
+          + "to one that doesn't exist? Please try again."));
+    }
+
+    if (!request.getAggregationFunc().isPresent()) {
+      return Optional.of(new QueryResult(Status.FAILURE,
+          "I can't tell if you want to know the number of rows or the average, "
+          + "sum, min, or max of a particular column in the "
+          + request.getFromTable().get() + " table. Please try again."));
+    }
+
+    if (!request.getAggregationFunc().get().equals("COUNT")
+        && !request.getAggregationColumn().isPresent()) {
+      return Optional.of(new QueryResult(Status.FAILURE,
+          "I'm not sure what column you want me to find the "
+          + SlotUtil.aggregationFunctionToEnglish(
+              request.getAggregationFunc().get())
+          + " over from the " + request.getFromTable().get()
+          + " table. Please try again."));
+    }
+
+    for (int i = 0; i < request.getComparisonColumns().size(); i++) {
+      String index = "";
+      switch (i) {
+        case 0:
+          index = "first";
+          break;
+        case 1:
+          index = "second";
+          break;
+        case 2:
+          index = "third";
+          break;
+      }
+
+      if (!request.getComparisonColumns().get(i).isPresent()) {
+        return Optional.of(new QueryResult(Status.FAILURE,
+            "I can't tell what column you're interested in filtering on in "
+            + "your " + index + " where clause. Please try again."));
+      }
+      if (!request.getComparators().get(i).isPresent()) {
+        return Optional.of(new QueryResult(Status.FAILURE,
+            "I can't tell if you are looking for values equal to, greater than,"
+            + " or less than the specified value in the "
+            + request.getComparisonColumns().get(i).get() + " column in your "
+            + index + " where clause. Please try again."));
+      }
+      if (!request.getComparisonValues().get(i).isPresent()) {
+        return Optional.of(new QueryResult(Status.FAILURE,
+            "I can't tell if in your " + index + " where clause, you are "
+            + "looking for values in the "
+            + request.getComparisonColumns().get(i).get() + " column"
+            + SlotUtil.comparisonTypeToEnglish(
+                request.getComparators().get(i).get())
+            + "what value. Please try again."));
+      }
+      if (i < request.getComparisonColumns().size() - 1
+          && (i >= request.getComparisonBinaryOperators().size()
+              || !request.getComparisonBinaryOperators().get(i).isPresent())) {
+        return Optional.of(new QueryResult(Status.FAILURE,
+            "It seems like you have more than one where condition but no and "
+            + "or or connecting them, and I'm not sure what to do with this."
+            + " Please try again."));
+      }
+    }
+
+    return Optional.empty();
   }
 }

--- a/src/main/java/echoquery/sql/QueryResult.java
+++ b/src/main/java/echoquery/sql/QueryResult.java
@@ -2,10 +2,6 @@ package echoquery.sql;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.ComparisonExpression;
@@ -21,6 +17,11 @@ import com.facebook.presto.sql.tree.StringLiteral;
 
 import echoquery.utils.SlotUtil;
 import echoquery.utils.TranslationUtils;
+
+/**
+ * The QueryResult class contains a status of a query request and a message for
+ * the end user.
+ */
 
 public class QueryResult {
   enum Status {
@@ -44,7 +45,15 @@ public class QueryResult {
     return message;
   }
 
+  /**
+   * Builds a QueryResult out of a JDBC result set, and original request object.
+   * @param request
+   * @param result
+   * @return A successful result where the message is the result of the query
+   *    is in end-user natural language.
+   */
   public static QueryResult of(QueryRequest request, ResultSet result) {
+    // Get the answer as a double to cover decimal values.
     double value;
     try {
       result.first();

--- a/src/main/java/echoquery/sql/SingletonConnection.java
+++ b/src/main/java/echoquery/sql/SingletonConnection.java
@@ -15,7 +15,7 @@ public final class SingletonConnection {
 
   private static final String URI =
       "jdbc:mysql://speechql.cutq0x5qwogl.us-east-1.rds.amazonaws.com:3306/";
-  private static final String DB = "airlines";
+  private static final String DB = "bestbuy";
 
   private static Connection instance = null;
   static {

--- a/src/main/java/echoquery/utils/SlotUtil.java
+++ b/src/main/java/echoquery/utils/SlotUtil.java
@@ -173,6 +173,23 @@ public final class SlotUtil {
     return null;
   }
 
+  public static String aggregationFunctionToEnglish(String aggregate) {
+    switch (aggregate) {
+      case "COUNT":
+        return "count";
+      case "AVG":
+        return "average";
+      case "SUM":
+        return "total";
+      case "MIN":
+        return "minimum value";
+      case "MAX":
+        return "maximum value";
+      default:
+        return null;
+    }
+  }
+
   public static ComparisonExpression.Type getComparisonType(String expression) {
     if (equalsExpr.contains(expression)) {
       return ComparisonExpression.Type.EQUAL;
@@ -193,6 +210,25 @@ public final class SlotUtil {
       return ComparisonExpression.Type.LESS_THAN_OR_EQUAL;
     }
     return null;
+  }
+
+  public static String comparisonTypeToEnglish(ComparisonExpression.Type type) {
+    switch (type) {
+      case EQUAL:
+        return " equal to ";
+      case NOT_EQUAL:
+        return " not equal to ";
+      case LESS_THAN:
+        return " less than ";
+      case GREATER_THAN:
+        return " greater than ";
+      case GREATER_THAN_OR_EQUAL:
+        return " greater than or equal to ";
+      case IS_DISTINCT_FROM:
+        return " is distinct from ";
+      default:
+        return null;
+    }
   }
 
   public static LogicalBinaryExpression.Type getComparisonBinaryOperatorType(

--- a/src/test/java/echoquery/AggregationHandlerTest.java
+++ b/src/test/java/echoquery/AggregationHandlerTest.java
@@ -17,6 +17,28 @@ public class AggregationHandlerTest {
   AggregationHandler handler =
       new AggregationHandler(TestConnection.getInstance());
 
+  private Map<String, Slot> newEmptySlots() {
+    Map<String, Slot> slots = new HashMap<>();
+    addSlotValue(slots, SlotUtil.TABLE_NAME, null);
+    addSlotValue(slots, SlotUtil.AGGREGATE, null);
+    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
+    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
+    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
+    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
+    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
+    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
+    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
+    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
+    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
+    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
+    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
+    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
+    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
+    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
+    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
+    return slots;
+  }
+
   private void addSlotValue(
       Map<String, Slot> slots, String slotName, String slotValue) {
     slots.put(slotName,
@@ -31,167 +53,73 @@ public class AggregationHandlerTest {
 
   @Test
   public void testCountWithoutWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "how many");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "There are four rows in the sales table.");
   }
 
   @Test
   public void testAverageWithoutWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "average");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "count");
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The average of the count column in the sales table "
         + "is two point two five.");
   }
 
   @Test
   public void testSumWithoutWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "total");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "count");
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The total of the count column in the sales table "
         + "is nine.");
   }
 
   @Test
   public void testMinWithoutWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "minimum");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "count");
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The minimum value of the count column in the sales "
         + "table is one.");
   }
 
   @Test
   public void testMaxWithoutWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "maximum");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "count");
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The maximum value of the count column in the sales "
         + "table is three.");
   }
 
   @Test
   public void testWithEnumeratedWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "how many");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "product");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "speakers");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "There are two rows in the sales table"
         + " where the value in the product column is equal to speakers.");
   }
 
   @Test
   public void testWithNumericalWhere() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "jobs");
     addSlotValue(slots, SlotUtil.AGGREGATE, "average");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "salary");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "salary");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is greater than");
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, null);
     addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, "15");
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The average of the salary column in the jobs table "
         + "where the value in the salary column is greater than fifteen is "
         + "two hundred sixty.");
@@ -199,24 +127,16 @@ public class AggregationHandlerTest {
 
   @Test
   public void testWithTwoWhereClauses() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "how many");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "product");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "speakers");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, "store");
     addSlotValue(slots, SlotUtil.COMPARATOR_2, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, "warwick");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "There is one row in the sales table"
         + " where the value in the product column is equal to speakers and"
         + " the store column is not equal to warwick.");
@@ -224,23 +144,19 @@ public class AggregationHandlerTest {
 
   @Test
   public void testWithThreeWhereClauses() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "how many");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "product");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "speakers");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, "store");
     addSlotValue(slots, SlotUtil.COMPARATOR_2, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, "warwick");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, "count");
     addSlotValue(slots, SlotUtil.COMPARATOR_3, "greater than");
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
     addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, "5");
     assertResponse(slots, "There are zero rows in the sales table"
         + " where the value in the product column is equal to speakers and"
@@ -250,24 +166,21 @@ public class AggregationHandlerTest {
 
   @Test
   public void testWithThreeWhereClausesWithOrderOfOperations() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "sales");
     addSlotValue(slots, SlotUtil.AGGREGATE, "average");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "count");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "product");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "speakers");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, "or");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, "store");
     addSlotValue(slots, SlotUtil.COMPARATOR_2, "is equal to");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, "pawtucket");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, "product");
     addSlotValue(slots, SlotUtil.COMPARATOR_3, "is equal to");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, "camera");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The average of the count column in the sales table"
         + " where the value in the product column is equal to speakers or"
         + " the store column is equal to pawtucket and the product column is"
@@ -276,24 +189,13 @@ public class AggregationHandlerTest {
 
   @Test
   public void testRequiringJoinForAggregationColumn() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "employees");
     addSlotValue(slots, SlotUtil.AGGREGATE, "average");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "salary");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "name");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "vinh");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The average of the salary column in the employees "
         + "table where the value in the name column is not equal to vinh is "
         + "two hundred fifty five.");
@@ -301,48 +203,28 @@ public class AggregationHandlerTest {
 
   @Test
   public void testRequiringJoinForFirstComparisonColumn() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "employees");
     addSlotValue(slots, SlotUtil.AGGREGATE, "count");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "title");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "professor");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "There are two rows in the employees table where the "
         + "value in the title column is not equal to professor.");
   }
 
   @Test
   public void testRequiringJoinForSecondComparisonColumn() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "employees");
     addSlotValue(slots, SlotUtil.AGGREGATE, "count");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "name");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "vinh");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, "title");
     addSlotValue(slots, SlotUtil.COMPARATOR_2, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, "professor");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "There is one row in the employees table where the "
         + "value in the name column is not equal to vinh and the title column "
         + "is not equal to professor.");
@@ -350,23 +232,19 @@ public class AggregationHandlerTest {
 
   @Test
   public void testRequiringJoinForThirdComparisonColumn() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "employees");
     addSlotValue(slots, SlotUtil.AGGREGATE, "count");
-    addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, null);
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "name");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "vinh");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, "title");
     addSlotValue(slots, SlotUtil.COMPARATOR_2, "is");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, "professor");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
     addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, "and");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, "salary");
     addSlotValue(slots, SlotUtil.COMPARATOR_3, "is greater than");
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
     addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, "100");
     assertResponse(slots, "There is one row in the employees table where the "
         + "value in the name column is not equal to vinh and the title column "
@@ -376,24 +254,13 @@ public class AggregationHandlerTest {
 
   @Test
   public void testRequiringJoinForBothAggregateAndComparisonColumns() {
-    Map<String, Slot> slots = new HashMap<>();
+    Map<String, Slot> slots = newEmptySlots();
     addSlotValue(slots, SlotUtil.TABLE_NAME, "employees");
     addSlotValue(slots, SlotUtil.AGGREGATE, "average");
     addSlotValue(slots, SlotUtil.AGGREGATION_COLUMN, "salary");
     addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_1, "title");
     addSlotValue(slots, SlotUtil.COMPARATOR_1, "is not");
     addSlotValue(slots, SlotUtil.COLUMN_VALUE_1, "professor");
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_1, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_1, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_2, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_2, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_2, null);
-    addSlotValue(slots, SlotUtil.BINARY_LOGIC_OP_2, null);
-    addSlotValue(slots, SlotUtil.COMPARISON_COLUMN_3, null);
-    addSlotValue(slots, SlotUtil.COMPARATOR_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_VALUE_3, null);
-    addSlotValue(slots, SlotUtil.COLUMN_NUMBER_3, null);
     assertResponse(slots, "The average of the salary column in the employees "
         + "table where the value in the title column is not equal to professor "
         + "is ten.");


### PR DESCRIPTION
Refactored the QueryResult object to be truer to its name.
Querier now does a validation step that walks over a QueryRequest and
checks if all expected fields are there. If not, it makes Alexa announce
a useful error message.

Next step re handling errors:
  - Make these error responses interactive. Alexa will try to
    interactively fix invalid requests with you.
  - Fix up SchemaInferrer / errors where column/table doesn't exist.
    For example, right now:

    how many sales where product is speakers and counts are nine

    fails because SchemaInferrer tries to look up counts but it doesn't
    exist, only count does. This null pointers, when it really should
    propagate some error upwards back to the user.